### PR TITLE
fix: environment variables not being evaluated

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+eval set -- "$@"
+
 RELEASE_NOTES="$(/release-notes-generator "$@")"
 
 RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"


### PR DESCRIPTION
The `$KOTS_VERSION` environment variable was not being evaluated by the script, resulting in:
```
Failed to get release notes: GET https://api.github.com/repos/replicatedhq/kots/compare/v1.86.0...%24KOTS_VERSION?per_page=100: 404 Not Found []
```

This change fixes that (at least when running locally).  Tested with the following:
```
export KOTS_VERSION=some-version

export GITHUB_AUTH_TOKEN=my-token

docker run --rm -e KOTS_VERSION -e GITHUB_AUTH_TOKEN ttl.sh/craig/kots-release-helper:2h '--owner-repo=replicatedhq/kots' '--base=v1.86.0' '--head=$KOTS_VERSION' '--title=${KOTS_VERSION#v}' '--description="my-description"' '--feature-type-labels=type::feature' '--improvement-type-labels=type::improvement' '--bug-type-labels=type::bug'
```