### PR TITLE
Check for errors before accessing notes to prevent nil pointer

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,14 +109,13 @@ func main() {
 	}
 
 	notes, err := getAllReleaseNotes(ctx, client, owner, repo, base, head, includePrLinks, typeLabelFlags)
+	if err != nil {
+		log.Fatalf("Failed to get release notes: %v", err)
+	}
 
 	// if the release notes do not contain any features, improvements, or bugs, do not submit release notes
 	if len(notes.Features) == 0 && len(notes.Improvements) == 0 && len(notes.Bugs) == 0 {
 		return
-	}
-
-	if err != nil {
-		log.Fatalf("Failed to get release notes: %v", err)
 	}
 
 	notes.Title = title


### PR DESCRIPTION
Getting release notes setup for the Embedded Cluster repo and ran into the following:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x748905]

goroutine 1 [running]:
main.main()
	/app/main.go:114 +0x665
```

https://github.com/replicatedhq/replicated-docs/actions/runs/15021649532/job/42212034481
