### PR TITLE
Emit release-notes via $GITHUB_OUTPUT instead of disabled set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,12 @@ eval set -- "$@"
 
 RELEASE_NOTES="$(/release-notes-generator "$@")"
 
-RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
-RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-
-echo "::set-output name=release-notes::$RELEASE_NOTES"
+# GitHub disabled the legacy `::set-output` workflow command, so write the
+# (multi-line) result to the step output via the environment file instead.
+# A random delimiter avoids any collision with the release-notes content.
+delimiter="ghadelimiter_$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+{
+  printf 'release-notes<<%s\n' "$delimiter"
+  printf '%s\n' "$RELEASE_NOTES"
+  printf '%s\n' "$delimiter"
+} >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What this PR does

Fixes the action so it stops returning empty output. It now writes the generated release notes to the step output via the `$GITHUB_OUTPUT` environment file instead of the legacy `::set-output` workflow command.

## Why

GitHub disabled `::set-output` in recent runner versions (it now only prints a deprecation warning and ignores the command). Because this action returned its result with `echo "::set-output name=release-notes::..."`, the `release-notes` output silently became empty. Every workflow that consumes this action — vendor-portal, replicated-sdk, embedded-cluster, kots, etc. release notes — then generated nothing and opened no PR, while the job still exited 0 (so it looked successful).

This is why Vendor Platform release notes have had no PRs since ~June 8.

## The change

- Emit `release-notes` via `$GITHUB_OUTPUT` using a random heredoc delimiter (multi-line safe).
- Drop the `%25`/`%0A`/`%0D` escaping — that was only required for `set-output`'s encoding, and it also mangled literal `%` signs in release notes.

Workflows pin this action at `@main` and it is built from source each run, so consumers recover automatically once this merges — no changes needed in replicated-docs or any product repo.

## Verification

Simulated the output block with multi-line content containing `%`, `<>`, backticks, and blank lines; the value written to `$GITHUB_OUTPUT` round-trips and parses back identically.

Note: this fixes generation going forward. The ~2.5 weeks of already-missed notes (June 8 → now) will need a separate catch-up run over that version range.
