### PR TITLE
Supporting the New Three-Block Release Note Template

### DIFF
--- a/main.go
+++ b/main.go
@@ -240,22 +240,13 @@ func getAllReleaseNotes(ctx context.Context, client *github.Client, owner, repo,
 				text = fmt.Sprintf("[#%d](%s) %s", prNumber, *pr.HTMLURL, text)
 			}
 
-			switch en.Category {
+			switch classifyNote(en, pr.Labels, typeLabelFlags) {
 			case CategoryFeature:
 				releaseNotes.Features = append(releaseNotes.Features, text)
 			case CategoryBug:
 				releaseNotes.Bugs = append(releaseNotes.Bugs, text)
 			case CategoryImprovement:
 				releaseNotes.Improvements = append(releaseNotes.Improvements, text)
-			case CategoryUnspecified:
-				switch typeLabelFlags.GetNoteTypeFromLabels(pr.Labels) {
-				case "feature":
-					releaseNotes.Features = append(releaseNotes.Features, text)
-				case "improvement":
-					releaseNotes.Improvements = append(releaseNotes.Improvements, text)
-				case "bug":
-					releaseNotes.Bugs = append(releaseNotes.Bugs, text)
-				}
 			}
 		}
 	}
@@ -275,6 +266,23 @@ const (
 type ExtractedNote struct {
 	Text     string
 	Category NoteCategory
+}
+
+func classifyNote(en ExtractedNote, prLabels []*github.Label, typeLabelFlags *TypeLabelFlags) NoteCategory {
+	switch en.Category {
+	case CategoryFeature, CategoryBug, CategoryImprovement:
+		return en.Category
+	case CategoryUnspecified:
+		switch typeLabelFlags.GetNoteTypeFromLabels(prLabels) {
+		case "feature":
+			return CategoryFeature
+		case "improvement":
+			return CategoryImprovement
+		case "bug":
+			return CategoryBug
+		}
+	}
+	return ""
 }
 
 func getReleaseNotes(raw string) []ExtractedNote {

--- a/main.go
+++ b/main.go
@@ -229,26 +229,33 @@ func getAllReleaseNotes(ctx context.Context, client *github.Client, owner, repo,
 			continue
 		}
 
-		for _, note := range notes {
-			note = cleanReleaseNote(note)
+		for _, en := range notes {
+			text := cleanReleaseNote(en.Text)
 
-			if strings.EqualFold(note, "NONE") {
+			if strings.EqualFold(text, "NONE") || text == "" {
 				continue
 			}
 
 			if includePrLinks {
-				note = fmt.Sprintf("[#%d](%s) %s", prNumber, *pr.HTMLURL, note)
+				text = fmt.Sprintf("[#%d](%s) %s", prNumber, *pr.HTMLURL, text)
 			}
 
-			noteType := typeLabelFlags.GetNoteTypeFromLabels(pr.Labels)
-
-			switch noteType {
-			case "feature":
-				releaseNotes.Features = append(releaseNotes.Features, note)
-			case "improvement":
-				releaseNotes.Improvements = append(releaseNotes.Improvements, note)
-			case "bug":
-				releaseNotes.Bugs = append(releaseNotes.Bugs, note)
+			switch en.Category {
+			case CategoryFeature:
+				releaseNotes.Features = append(releaseNotes.Features, text)
+			case CategoryBug:
+				releaseNotes.Bugs = append(releaseNotes.Bugs, text)
+			case CategoryImprovement:
+				releaseNotes.Improvements = append(releaseNotes.Improvements, text)
+			case CategoryUnspecified:
+				switch typeLabelFlags.GetNoteTypeFromLabels(pr.Labels) {
+				case "feature":
+					releaseNotes.Features = append(releaseNotes.Features, text)
+				case "improvement":
+					releaseNotes.Improvements = append(releaseNotes.Improvements, text)
+				case "bug":
+					releaseNotes.Bugs = append(releaseNotes.Bugs, text)
+				}
 			}
 		}
 	}
@@ -256,19 +263,49 @@ func getAllReleaseNotes(ctx context.Context, client *github.Client, owner, repo,
 	return &releaseNotes, nil
 }
 
-func getReleaseNotes(raw string) []string {
+type NoteCategory string
+
+const (
+	CategoryFeature     NoteCategory = "feature"
+	CategoryImprovement NoteCategory = "improvement"
+	CategoryBug         NoteCategory = "bug"
+	CategoryUnspecified NoteCategory = "unspecified"
+)
+
+type ExtractedNote struct {
+	Text     string
+	Category NoteCategory
+}
+
+func getReleaseNotes(raw string) []ExtractedNote {
 	md := markdown.New()
 	tokens := md.Parse([]byte(raw))
 
+	var out []ExtractedNote
 	for _, t := range tokens {
 		snippet := getSnippet(t)
 		snippet.content = strings.TrimSpace(snippet.content)
-		if snippet.content != "" && snippet.lang == "release-note" {
-			notes := strings.Split(snippet.content, "\n")
-			return notes
+		if snippet.content == "" {
+			continue
+		}
+		var cat NoteCategory
+		switch snippet.lang {
+		case "release-note":
+			cat = CategoryUnspecified
+		case "release-note-features":
+			cat = CategoryFeature
+		case "release-notes-fixes":
+			cat = CategoryBug
+		case "release-notes-improvements":
+			cat = CategoryImprovement
+		default:
+			continue
+		}
+		for _, line := range strings.Split(snippet.content, "\n") {
+			out = append(out, ExtractedNote{Text: line, Category: cat})
 		}
 	}
-	return []string{}
+	return out
 }
 
 // snippet represents the snippet we will output.

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/google/go-github/v43/github"
@@ -82,7 +81,7 @@ func TestGetReleaseNotes(t *testing.T) {
 	}
 }
 
-func TestClassifyExtractedNotes(t *testing.T) {
+func TestClassifyNote(t *testing.T) {
 	typeFeature := "type::feature"
 	typeImprovement := "type::improvement"
 	typeBug := "type::bug"
@@ -93,125 +92,63 @@ func TestClassifyExtractedNotes(t *testing.T) {
 		BugTypeLabels:         []string{typeBug},
 	}
 
-	htmlURL := "https://example.com/pr/1"
-
 	tests := []struct {
-		name           string
-		notes          []ExtractedNote
-		prLabels       []*github.Label
-		wantFeatures   []string
-		wantImprovements []string
-		wantBugs       []string
+		name       string
+		note       ExtractedNote
+		prLabels   []*github.Label
+		wantBucket NoteCategory
 	}{
 		{
-			name: "named fence overrides labels",
-			notes: []ExtractedNote{
-				{Text: "feat note", Category: CategoryFeature},
-			},
-			prLabels:       []*github.Label{{Name: &typeBug}},
-			wantFeatures:   []string{"feat note"},
-			wantImprovements: []string{},
-			wantBugs:       []string{},
+			name:       "named feature fence overrides bug label",
+			note:       ExtractedNote{Text: "feat note", Category: CategoryFeature},
+			prLabels:   []*github.Label{{Name: &typeBug}},
+			wantBucket: CategoryFeature,
 		},
 		{
-			name: "legacy note classified by feature label",
-			notes: []ExtractedNote{
-				{Text: "legacy feat", Category: CategoryUnspecified},
-			},
-			prLabels:       []*github.Label{{Name: &typeFeature}},
-			wantFeatures:   []string{"legacy feat"},
-			wantImprovements: []string{},
-			wantBugs:       []string{},
+			name:       "named bug fence overrides feature label",
+			note:       ExtractedNote{Text: "bug note", Category: CategoryBug},
+			prLabels:   []*github.Label{{Name: &typeFeature}},
+			wantBucket: CategoryBug,
 		},
 		{
-			name: "legacy note classified by improvement label overriding feature",
-			notes: []ExtractedNote{
-				{Text: "legacy improvement", Category: CategoryUnspecified},
-			},
+			name:       "named improvement fence overrides feature label",
+			note:       ExtractedNote{Text: "impr note", Category: CategoryImprovement},
+			prLabels:   []*github.Label{{Name: &typeFeature}},
+			wantBucket: CategoryImprovement,
+		},
+		{
+			name:       "legacy note classified by feature label",
+			note:       ExtractedNote{Text: "legacy feat", Category: CategoryUnspecified},
+			prLabels:   []*github.Label{{Name: &typeFeature}},
+			wantBucket: CategoryFeature,
+		},
+		{
+			name:       "legacy note classified by bug label",
+			note:       ExtractedNote{Text: "legacy bug", Category: CategoryUnspecified},
+			prLabels:   []*github.Label{{Name: &typeBug}},
+			wantBucket: CategoryBug,
+		},
+		{
+			name:       "legacy note improvement label overrides feature label",
+			note:       ExtractedNote{Text: "legacy improvement", Category: CategoryUnspecified},
 			prLabels: []*github.Label{
 				{Name: &typeFeature},
 				{Name: &typeImprovement},
 			},
-			wantFeatures:     []string{},
-			wantImprovements: []string{"legacy improvement"},
-			wantBugs:         []string{},
+			wantBucket: CategoryImprovement,
 		},
 		{
-			name: "legacy note with no matching label is dropped",
-			notes: []ExtractedNote{
-				{Text: "orphan note", Category: CategoryUnspecified},
-			},
-			prLabels:         []*github.Label{{Name: ptrString("kind::misc")}},
-			wantFeatures:     []string{},
-			wantImprovements: []string{},
-			wantBugs:         []string{},
-		},
-		{
-			name: "NONE skipped in legacy fence",
-			notes: []ExtractedNote{
-				{Text: "NONE", Category: CategoryUnspecified},
-			},
-			prLabels:         []*github.Label{{Name: &typeFeature}},
-			wantFeatures:     []string{},
-			wantImprovements: []string{},
-			wantBugs:         []string{},
-		},
-		{
-			name: "NONE skipped in named fence",
-			notes: []ExtractedNote{
-				{Text: "NONE", Category: CategoryFeature},
-			},
-			prLabels:         []*github.Label{{Name: &typeFeature}},
-			wantFeatures:     []string{},
-			wantImprovements: []string{},
-			wantBugs:         []string{},
+			name:       "legacy note with no matching label is dropped",
+			note:       ExtractedNote{Text: "orphan note", Category: CategoryUnspecified},
+			prLabels:   []*github.Label{{Name: ptrString("kind::misc")}},
+			wantBucket: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			releaseNotes := &ReleaseNotes{
-				Features:     []string{},
-				Improvements: []string{},
-				Bugs:         []string{},
-			}
-			pr := &github.PullRequest{
-				HTMLURL: &htmlURL,
-				Labels:  tt.prLabels,
-			}
-
-			for _, en := range tt.notes {
-				text := cleanReleaseNote(en.Text)
-				if strings.EqualFold(text, "NONE") || text == "" {
-					continue
-				}
-				switch en.Category {
-				case CategoryFeature:
-					releaseNotes.Features = append(releaseNotes.Features, text)
-				case CategoryBug:
-					releaseNotes.Bugs = append(releaseNotes.Bugs, text)
-				case CategoryImprovement:
-					releaseNotes.Improvements = append(releaseNotes.Improvements, text)
-				case CategoryUnspecified:
-					switch typeLabelFlags.GetNoteTypeFromLabels(pr.Labels) {
-					case "feature":
-						releaseNotes.Features = append(releaseNotes.Features, text)
-					case "improvement":
-						releaseNotes.Improvements = append(releaseNotes.Improvements, text)
-					case "bug":
-						releaseNotes.Bugs = append(releaseNotes.Bugs, text)
-					}
-				}
-			}
-
-			if !reflect.DeepEqual(releaseNotes.Features, tt.wantFeatures) {
-				t.Errorf("Features = %#v, want %#v", releaseNotes.Features, tt.wantFeatures)
-			}
-			if !reflect.DeepEqual(releaseNotes.Improvements, tt.wantImprovements) {
-				t.Errorf("Improvements = %#v, want %#v", releaseNotes.Improvements, tt.wantImprovements)
-			}
-			if !reflect.DeepEqual(releaseNotes.Bugs, tt.wantBugs) {
-				t.Errorf("Bugs = %#v, want %#v", releaseNotes.Bugs, tt.wantBugs)
+			if got := classifyNote(tt.note, tt.prLabels, typeLabelFlags); got != tt.wantBucket {
+				t.Errorf("classifyNote() = %v, want %v", got, tt.wantBucket)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v43/github"
+)
+
+func TestGetReleaseNotes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []ExtractedNote
+	}{
+		{
+			name: "legacy single release-note block",
+			raw: "Some text\n" +
+				"```release-note\n" +
+				"Added a new thing\n" +
+				"Removed an old thing\n" +
+				"```\n",
+			want: []ExtractedNote{
+				{Text: "Added a new thing", Category: CategoryUnspecified},
+				{Text: "Removed an old thing", Category: CategoryUnspecified},
+			},
+		},
+		{
+			name: "new three-block template",
+			raw: "```release-note-features\n" +
+				"New feature A\n" +
+				"```\n" +
+				"```release-notes-fixes\n" +
+				"Fixed bug B\n" +
+				"```\n" +
+				"```release-notes-improvements\n" +
+				"Improved thing C\n" +
+				"```\n",
+			want: []ExtractedNote{
+				{Text: "New feature A", Category: CategoryFeature},
+				{Text: "Fixed bug B", Category: CategoryBug},
+				{Text: "Improved thing C", Category: CategoryImprovement},
+			},
+		},
+		{
+			name: "mixed legacy and named fences",
+			raw: "```release-note\n" +
+				"Legacy note\n" +
+				"```\n" +
+				"```release-note-features\n" +
+				"Named feature note\n" +
+				"```\n",
+			want: []ExtractedNote{
+				{Text: "Legacy note", Category: CategoryUnspecified},
+				{Text: "Named feature note", Category: CategoryFeature},
+			},
+		},
+		{
+			name: "release-note block with only NONE",
+			raw: "```release-note\n" +
+				"NONE\n" +
+				"```\n",
+			want: []ExtractedNote{
+				{Text: "NONE", Category: CategoryUnspecified},
+			},
+		},
+		{
+			name: "no release-note fences at all",
+			raw:  "Just some prose, no fences here.",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getReleaseNotes(tt.raw)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getReleaseNotes() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyExtractedNotes(t *testing.T) {
+	typeFeature := "type::feature"
+	typeImprovement := "type::improvement"
+	typeBug := "type::bug"
+
+	typeLabelFlags := &TypeLabelFlags{
+		FeatureTypeLabels:     []string{typeFeature},
+		ImprovementTypeLabels: []string{typeImprovement},
+		BugTypeLabels:         []string{typeBug},
+	}
+
+	htmlURL := "https://example.com/pr/1"
+
+	tests := []struct {
+		name           string
+		notes          []ExtractedNote
+		prLabels       []*github.Label
+		wantFeatures   []string
+		wantImprovements []string
+		wantBugs       []string
+	}{
+		{
+			name: "named fence overrides labels",
+			notes: []ExtractedNote{
+				{Text: "feat note", Category: CategoryFeature},
+			},
+			prLabels:       []*github.Label{{Name: &typeBug}},
+			wantFeatures:   []string{"feat note"},
+			wantImprovements: []string{},
+			wantBugs:       []string{},
+		},
+		{
+			name: "legacy note classified by feature label",
+			notes: []ExtractedNote{
+				{Text: "legacy feat", Category: CategoryUnspecified},
+			},
+			prLabels:       []*github.Label{{Name: &typeFeature}},
+			wantFeatures:   []string{"legacy feat"},
+			wantImprovements: []string{},
+			wantBugs:       []string{},
+		},
+		{
+			name: "legacy note classified by improvement label overriding feature",
+			notes: []ExtractedNote{
+				{Text: "legacy improvement", Category: CategoryUnspecified},
+			},
+			prLabels: []*github.Label{
+				{Name: &typeFeature},
+				{Name: &typeImprovement},
+			},
+			wantFeatures:     []string{},
+			wantImprovements: []string{"legacy improvement"},
+			wantBugs:         []string{},
+		},
+		{
+			name: "legacy note with no matching label is dropped",
+			notes: []ExtractedNote{
+				{Text: "orphan note", Category: CategoryUnspecified},
+			},
+			prLabels:         []*github.Label{{Name: ptrString("kind::misc")}},
+			wantFeatures:     []string{},
+			wantImprovements: []string{},
+			wantBugs:         []string{},
+		},
+		{
+			name: "NONE skipped in legacy fence",
+			notes: []ExtractedNote{
+				{Text: "NONE", Category: CategoryUnspecified},
+			},
+			prLabels:         []*github.Label{{Name: &typeFeature}},
+			wantFeatures:     []string{},
+			wantImprovements: []string{},
+			wantBugs:         []string{},
+		},
+		{
+			name: "NONE skipped in named fence",
+			notes: []ExtractedNote{
+				{Text: "NONE", Category: CategoryFeature},
+			},
+			prLabels:         []*github.Label{{Name: &typeFeature}},
+			wantFeatures:     []string{},
+			wantImprovements: []string{},
+			wantBugs:         []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			releaseNotes := &ReleaseNotes{
+				Features:     []string{},
+				Improvements: []string{},
+				Bugs:         []string{},
+			}
+			pr := &github.PullRequest{
+				HTMLURL: &htmlURL,
+				Labels:  tt.prLabels,
+			}
+
+			for _, en := range tt.notes {
+				text := cleanReleaseNote(en.Text)
+				if strings.EqualFold(text, "NONE") || text == "" {
+					continue
+				}
+				switch en.Category {
+				case CategoryFeature:
+					releaseNotes.Features = append(releaseNotes.Features, text)
+				case CategoryBug:
+					releaseNotes.Bugs = append(releaseNotes.Bugs, text)
+				case CategoryImprovement:
+					releaseNotes.Improvements = append(releaseNotes.Improvements, text)
+				case CategoryUnspecified:
+					switch typeLabelFlags.GetNoteTypeFromLabels(pr.Labels) {
+					case "feature":
+						releaseNotes.Features = append(releaseNotes.Features, text)
+					case "improvement":
+						releaseNotes.Improvements = append(releaseNotes.Improvements, text)
+					case "bug":
+						releaseNotes.Bugs = append(releaseNotes.Bugs, text)
+					}
+				}
+			}
+
+			if !reflect.DeepEqual(releaseNotes.Features, tt.wantFeatures) {
+				t.Errorf("Features = %#v, want %#v", releaseNotes.Features, tt.wantFeatures)
+			}
+			if !reflect.DeepEqual(releaseNotes.Improvements, tt.wantImprovements) {
+				t.Errorf("Improvements = %#v, want %#v", releaseNotes.Improvements, tt.wantImprovements)
+			}
+			if !reflect.DeepEqual(releaseNotes.Bugs, tt.wantBugs) {
+				t.Errorf("Bugs = %#v, want %#v", releaseNotes.Bugs, tt.wantBugs)
+			}
+		})
+	}
+}
+
+func ptrString(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Add support for `release-note-features`, `release-notes-fixes`, and `release-notes-improvements` blocks. The current `release-note` block is still supported and works the same way as before.
